### PR TITLE
fix: Correct float64 conversion for MPS compatibility

### DIFF
--- a/wan/modules/model.py
+++ b/wan/modules/model.py
@@ -15,7 +15,7 @@ def sinusoidal_embedding_1d(dim, position):
     # preprocess
     assert dim % 2 == 0
     half = dim // 2
-    position = position.type(torch.float64)
+    position = position.type(torch.float32)
 
     # calculation
     sinusoid = torch.outer(


### PR DESCRIPTION
This change addresses a `TypeError` that occurs when running on Apple Silicon (MPS) devices. The MPS framework does not support `float64` tensors, and the `sinusoidal_embedding_1d` function was attempting to cast a tensor to this unsupported dtype.

This commit changes the cast from `torch.float64` to `torch.float32` in `wan/modules/model.py` to ensure compatibility with MPS.