### PR TITLE
fix: Use float32 in rope_apply for MPS compatibility

### DIFF
--- a/wan/distributed/sequence_parallel.py
+++ b/wan/distributed/sequence_parallel.py
@@ -36,7 +36,7 @@ def rope_apply(x, grid_sizes, freqs):
         seq_len = f * h * w
 
         # precompute multipliers
-        x_i = torch.view_as_complex(x[i, :s].to(torch.float64).reshape(
+        x_i = torch.view_as_complex(x[i, :s].to(torch.float32).reshape(
             s, n, -1, 2))
         freqs_i = torch.cat([
             freqs[0][:f].view(f, 1, 1, -1).expand(f, h, w, -1),

--- a/wan/modules/model.py
+++ b/wan/modules/model.py
@@ -48,7 +48,7 @@ def rope_apply(x, grid_sizes, freqs):
         seq_len = f * h * w
 
         # precompute multipliers
-        x_i = torch.view_as_complex(x[i, :seq_len].to(torch.float64).reshape(
+        x_i = torch.view_as_complex(x[i, :seq_len].to(torch.float32).reshape(
             seq_len, n, -1, 2))
         freqs_i = torch.cat([
             freqs[0][:f].view(f, 1, 1, -1).expand(f, h, w, -1),

--- a/wan/modules/s2v/model_s2v.py
+++ b/wan/modules/s2v/model_s2v.py
@@ -64,7 +64,7 @@ def rope_apply(x, grid_sizes, freqs, start=None):
     output = []
     for i, _ in enumerate(x):
         s = x.size(1)
-        x_i = torch.view_as_complex(x[i, :s].to(torch.float64).reshape(
+        x_i = torch.view_as_complex(x[i, :s].to(torch.float32).reshape(
             s, n, -1, 2))
         freqs_i = freqs[i, :s]
         # apply rotary embedding
@@ -83,7 +83,7 @@ def rope_apply_usp(x, grid_sizes, freqs):
     for i, _ in enumerate(x):
         s = x.size(1)
         # precompute multipliers
-        x_i = torch.view_as_complex(x[i, :s].to(torch.float64).reshape(
+        x_i = torch.view_as_complex(x[i, :s].to(torch.float32).reshape(
             s, n, -1, 2))
         freqs_i = freqs[i]
         freqs_i_rank = freqs_i


### PR DESCRIPTION
This commit fixes a `TypeError` that occurs when running on Apple Silicon (MPS) devices. The `rope_apply` function in several files was attempting to cast tensors to `torch.float64`, which is not supported by the MPS framework and caused an assertion failure in the underlying Metal Performance Shaders library.

This change modifies the `rope_apply` functions in `wan/modules/model.py`, `wan/modules/s2v/model_s2v.py`, and `wan/distributed/sequence_parallel.py` to use `torch.float32` instead, ensuring compatibility with MPS.