### PR TITLE
fix: Ensure rope_apply returns correct dtype for MPS

### DIFF
--- a/wan/distributed/sequence_parallel.py
+++ b/wan/distributed/sequence_parallel.py
@@ -57,7 +57,7 @@ def rope_apply(x, grid_sizes, freqs):
 
         # append to collection
         output.append(x_i)
-    return torch.stack(output).float()
+    return torch.stack(output).type_as(x)
 
 
 def sp_dit_forward(

--- a/wan/modules/model.py
+++ b/wan/modules/model.py
@@ -63,7 +63,7 @@ def rope_apply(x, grid_sizes, freqs):
 
         # append to collection
         output.append(x_i)
-    return torch.stack(output).float()
+    return torch.stack(output).type_as(x)
 
 
 class WanRMSNorm(nn.Module):

--- a/wan/modules/s2v/model_s2v.py
+++ b/wan/modules/s2v/model_s2v.py
@@ -72,7 +72,7 @@ def rope_apply(x, grid_sizes, freqs, start=None):
         x_i = torch.cat([x_i, x[i, s:]])
         # append to collection
         output.append(x_i)
-    return torch.stack(output).float()
+    return torch.stack(output).type_as(x)
 
 
 @torch.amp.autocast("cpu", enabled=False)
@@ -91,7 +91,7 @@ def rope_apply_usp(x, grid_sizes, freqs):
         x_i = torch.cat([x_i, x[i, s:]])
         # append to collection
         output.append(x_i)
-    return torch.stack(output).float()
+    return torch.stack(output).type_as(x)
 
 
 def sp_attn_forward_s2v(self,


### PR DESCRIPTION
This commit addresses a `TypeError` that occurs when running on Apple Silicon (MPS) devices. The `rope_apply` function in several files was returning a `float32` tensor, which caused a dtype mismatch in subsequent matrix multiplication operations on MPS, leading to an assertion failure.

This change modifies the `rope_apply` functions in `wan/modules/model.py`, `wan/modules/s2v/model_s2v.py`, and `wan/distributed/sequence_parallel.py` to return a tensor with the same dtype as the input tensor, ensuring compatibility with the MPS backend.